### PR TITLE
Do not copy the whole directory

### DIFF
--- a/build-gluster-org/scripts/bugs-summary.sh
+++ b/build-gluster-org/scripts/bugs-summary.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 ./run-report.sh
 
-scp -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" -i "$LOG_KEY" -r . _bits-gluster@http.int.rht.gluster.org:/var/www/glusterfs-bugs
+scp -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" -i "$LOG_KEY" -r gluster-bugs.html gluster-bugs.js bugs.json style.css _bits-gluster@http.int.rht.gluster.org:/var/www/glusterfs-bugs


### PR DESCRIPTION
For some reason, git do create file without write permission, so
subsequent sync fail. By copying only the generated file, we avoid the
issue, even if this mean keeping the list of file to sync up to
date in that job.

