### PR TITLE
Use a generic name for the path

### DIFF
--- a/build-gluster-org/scripts/coverity.sh
+++ b/build-gluster-org/scripts/coverity.sh
@@ -22,7 +22,7 @@ cat <<EOF >> site.h
     #endif
 #endif
 EOF
-/opt/cov-analysis-linux64-2019.03/bin/cov-build --dir cov-int make -j ${nproc};
+/opt/coverity/bin/cov-build --dir cov-int make -j ${nproc};
 tar czvf glusterfs.tgz cov-int
 BUILD_DATE=$(date "+%Y-%m-%d")
 BUILD_VERSION=$(git log -n1 --pretty='%h')


### PR DESCRIPTION
Since the automation do install coverity in a version agnostic place,
we can avoid hardcoding it here and keep it only in ansible.

Change-Id: Ie2f430ea49ca198e6a4626895ef31339cd80f5a4