### PR TITLE
Simplify the job and use F32

### DIFF
--- a/build-gluster-org/jobs/python-lint.yml
+++ b/build-gluster-org/jobs/python-lint.yml
@@ -1,9 +1,10 @@
 - job:
     name: python-lint
-    node: fedora30
+    node: fedora32
     description: python validation of code using pylint and flake8
     project-type: freestyle
     concurrent: true
+    wipe-workspace: True
 
     scm:
     - glusterfs

--- a/build-gluster-org/scripts/python-lint.sh
+++ b/build-gluster-org/scripts/python-lint.sh
@@ -6,19 +6,12 @@ mkdir $RESULT
 ./autogen.sh
 ./configure --enable-debug --enable-gnfs --silent
 
-# create and activate virtual env
-python3 -m venv env
-. env/bin/activate
-
-#install flake8 and pylint
-pip install -I flake8 pylint
-
 # run flake8
-find . -path './env' -prune -o -name '*.py' -print | xargs flake8 > "$RESULT/flake8-check.txt"
+find . -name '*.py' -print | xargs flake8 > "$RESULT/flake8-check.txt"
 FLAKE_COUNT="$(wc -l < $RESULT/flake8-check.txt)"
 
 #run pylint
-find . -path './env' -print -o -name '*.py' | xargs pylint --output-format=text > "$RESULT/pylint-check.txt"
+find . -name '*.py' -print | xargs pylint-3 --output-format=text > "$RESULT/pylint-check.txt"
 PYLINT_COUNT="$(egrep -wc 'R:|C:|W:|E:|F:' $RESULT/pylint-check.txt)"
 
 #fail build if there's any pylint and flake8 related issues


### PR DESCRIPTION
No longer use pip install, better use the packaged version
since we can control and test them. It also make the build
not dependent on external infra as much as before.

Also, it work, otherwise there is some recursive loop, see
https://build.gluster.org/job/python-lint/8887/console