### PR TITLE
centos-regression: fix the voting command string

### DIFF
--- a/build-gluster-org/scripts/centos-regression.sh
+++ b/build-gluster-org/scripts/centos-regression.sh
@@ -7,8 +7,8 @@ BURL=${BUILD_URL}consoleFull
 function vote_gerrit() {
     VOTE="$1"
     VERDICT="$2"
-    OUTPUT=$(cat $3)
-    ssh -o "StrictHostKeyChecking=no" -i "$GERRIT_BUILD_SSH_KEY" build@review.gluster.org gerrit review --message "'$BURL : $VERDICT'\n${OUTPUT}" --project=glusterfs --label CentOS-regression="$VOTE"  $GIT_COMMIT
+    OUTPUT=$(echo ; cat $3)
+    ssh -o "StrictHostKeyChecking=no" -i "$GERRIT_BUILD_SSH_KEY" build@review.gluster.org gerrit review --message "'$BURL : $VERDICT \n$OUTPUT'" --project=glusterfs --label CentOS-regression="$VOTE"  $GIT_COMMIT
 }
 
 # Display all environment variables in the debugging log


### PR DESCRIPTION
Looks like I misplaced output in previous patch.

Updates: gluster/project-infrastructure#72
Change-Id: I347795d369e35478586189c27f9521a4e07464c5
Signed-off-by: Amar Tumballi <amar@kadalu.io>