### PR TITLE
No need for SCL, should fix #77

### DIFF
--- a/build-gluster-org/scripts/glusto-lint.sh
+++ b/build-gluster-org/scripts/glusto-lint.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 set -e
-source /opt/rh/python27/enable
 virtualenv --system-site-packages env
 # see https://bugzilla.redhat.com/show_bug.cgi?id=1683650
 env/bin/pip install --upgrade pip


### PR DESCRIPTION
As nobody seems to know why we need SCL, I tested the change on https://build.gluster.org/job/glusto-tests-lint/6409/console and it seems to work. Ergo, remove we should remove that line, and I will do some cleanup ansible side as well.