### PR TITLE
Filter shellcheck results

### DIFF
--- a/build-gluster-org/scripts/shellcheck.sh
+++ b/build-gluster-org/scripts/shellcheck.sh
@@ -7,6 +7,19 @@ set -o pipefail
 find . -path ./.git -prune -o -path ./tests -prune -o -exec file {} \; \
   | grep "shell script" \
   | cut -d: -f 1 \
+  | grep -v '^./configure$' \
+  | grep -v '^./ltmain.sh$' \
+  | grep -v '^./libtool$' \
+  | grep -v '^./config.status$' \
+  | grep -v '^./config.guess$' \
+  | grep -v '^./install-sh$' \
+  | grep -v '^./depcomp$' \
+  | grep -v '^./compile$' \
+  | grep -v '^./config.sub$' \
+  | grep -v '^./test-driver$' \
+  | grep -v '^./build-aux/pkg-version$' \
+  | grep -v '^./autogen.sh$' \
+  | grep -v '^./missing$' \
   | xargs shellcheck \
   >shellcheck.txt
 

--- a/build-gluster-org/scripts/shellcheck.sh
+++ b/build-gluster-org/scripts/shellcheck.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-
+set -e
+set -o pipefail
 ./autogen.sh
 ./configure --enable-debug --enable-gnfs --silent
 


### PR DESCRIPTION
So, this one requires shellcheck to be installed on F32 nodes, not done yet. I will send also a PR for the job to fail if shellcheck is not here, unlike now as seen on https://build.gluster.org/job/gh_shellcheck/65/console 