### PR TITLE
Fix jjb syntax error

### DIFF
--- a/build-gluster-org/scripts/rpm-cleanup.sh
+++ b/build-gluster-org/scripts/rpm-cleanup.sh
@@ -18,5 +18,6 @@ sudo pkill -9 mock
 mount | grep /var/lib/mount/
 if [$? -eq 1 ]
 then
-    umount $(mount | grep /var/lib/mock/ | awk '{print $3}')
+    # {{is doubled to be escaped for jjb
+    umount $(mount | grep /var/lib/mock/ | awk '{{print $3}}')
 fi    


### PR DESCRIPTION
Since {} is used for formatting, jjb try to look for $3 as a key
and so throw 2 exceptions.