### PR TITLE
Update glusto-tests-lint.yml for GitHub workflow

### DIFF
--- a/build-gluster-org/jobs/glusto-tests-lint.yml
+++ b/build-gluster-org/jobs/glusto-tests-lint.yml
@@ -10,7 +10,6 @@
         branches:
         - $GITHUB_BRANCH
         refspec: $GITHUB_REFSPEC
-        choosing-strategy: gerrit
         url: https://github.com/gluster/glusto-tests.git
         wipe-workspace: true
 

--- a/build-gluster-org/jobs/glusto-tests-lint.yml
+++ b/build-gluster-org/jobs/glusto-tests-lint.yml
@@ -8,10 +8,10 @@
     scm:
     - git:
         branches:
-        - $GERRIT_BRANCH
-        refspec: $GERRIT_REFSPEC
+        - $GITHUB_BRANCH
+        refspec: $GITHUB_REFSPEC
         choosing-strategy: gerrit
-        url: git://review.gluster.org/glusto-tests.git
+        url: https://github.com/gluster/glusto-tests.git
         wipe-workspace: true
 
     properties:
@@ -20,36 +20,29 @@
     - one-build-per-node
 
     triggers:
-    - gerrit:
-        trigger-on:
-          - patchset-created-event:
-              exclude-drafts: false
-              exclude-trivial-rebase: false
-              exclude-no-code-change: false
-          - draft-published-event
-          - comment-added-contains-event:
-              comment-contains-value: "recheck"
-        override-votes: true
-        gerrit-build-successful-verified-value: 1
-        gerrit-build-failed-verified-value: -1
-        server-name: review.gluster.org
-        failure-message: This patch needs to be rebased to master and any pylint issues need to be fixed
-        projects:
-          - project-compare-type: 'PLAIN'
-            project-pattern: 'glusto-tests'
-            branches:
-              - branch-compare-type: 'ANT'
-                branch-pattern: '**'
+    - github-pull-request:
+        cancel-builds-on-update: true
+        allow-whitelist-orgs-as-admins: true
+        org-list:
+          - gluster
+        github-hooks: true
+        only-trigger-phrase: false
+        trigger-phrase: '/recheck'
+        permit-all: true
+        status-context: "Testing: python lint"
+        started-status: "Running: python lint"
+        success-status: "OK - python lint"
+        failure-status: "FAIL - This patch needs to be rebased to master and any pylint issues need to be fixed"
 
     parameters:
     - string:
         default: refs/heads/master
         description: 'For review 12345 and patch set 6, this will be refs/changes/45/12345/6. Default: Tip of master'
-        name: GERRIT_REFSPEC
+        name: GITHUB_REFSPEC
     - string:
         default: master
         description: 'Name of the branch you want to build from. We usually build from master'
-        name: GERRIT_BRANCH
+        name: GITHUB_BRANCH
 
     builders:
     - shell: !include-raw: ../scripts/glusto-lint.sh


### PR DESCRIPTION
We are currently moving glusto-tests from Gerrit(review.gluster.org) to Github workflow for which making changes to glusto-tests-lint.yml.

Reference issue: https://github.com/gluster/glusto-tests/issues/35