### PR TITLE
Update the CAcerts in the venv

### DIFF
--- a/build-gluster-org/scripts/jenkins-update.sh
+++ b/build-gluster-org/scripts/jenkins-update.sh
@@ -2,4 +2,8 @@
 set -e
 virtualenv env
 env/bin/pip install jenkins-job-builder
+# hack to update the certificate store
+# since that job is still running on python2, the pip installed requests module pull certifi, who has a older CA database
+# so it fail since the root CA of lets encrypt expired on 1st october 2021
+cp -f /etc/pki/tls/cert.pem  env/lib/python2.7/site-packages/certifi/cacert.pem
 env/bin/jenkins-jobs --conf $JJB_CONFIG update build-gluster-org/jobs


### PR DESCRIPTION
Due to the lets encrypt root certificate expiration, the bundled certifi
is unable to verify the LE issued certificate of jenkins, and so it fail

Real fix is to move to a supported python version, but this requires
more tests and work, so this workaround will have to do the trick for
now