### PR TITLE
Move the job to centos8 label

### DIFF
--- a/build-gluster-org/jobs/build-job.yml
+++ b/build-gluster-org/jobs/build-job.yml
@@ -1,6 +1,6 @@
 - job:
     name: build-job
-    node: smoke8
+    node: centos8
     description: Pre-commit tests for build-jobs
     project-type: freestyle
 

--- a/build-gluster-org/jobs/cppcheck.yml
+++ b/build-gluster-org/jobs/cppcheck.yml
@@ -1,6 +1,6 @@
 - job:
     name: cppcheck
-    node: smoke8
+    node: centos8
     description: Run cppcheck analysis on gluster code
     project-type: freestyle
     concurrent: true


### PR DESCRIPTION
No need to keep smoke8 builder, since they are equivalent to
smoke8, except in the cage, and there is no reason to be there anyway